### PR TITLE
Execute checks on multiple node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
   checks:
     runs-on: ubuntu-latest
 
-   strategy:
-        matrix:
-          node-version: [12, 14, 16]
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: node.js CI
 
 on:
   push: {}
@@ -6,10 +6,15 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
+
+   strategy:
+        matrix:
+          node-version: [12, 14, 16]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: ${{ matrix.node-version }}
       - run: sudo chmod +x ci/checks.sh
       - run: ci/checks.sh


### PR DESCRIPTION
To ensure the package operates well with later node versions, I have updated the CI script to run the same tests using node versions 12, 14 and 16.