### PR TITLE
Omit redundant checks during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,6 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: sudo chmod +x ci/checks.sh
-      - run: ci/checks.sh
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
On create release, this will trigger a push event - causing the checks to be run anyway.